### PR TITLE
Bump build number to sync `python.app` & `python`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.2
 
 build:
-  number: 1201
+  number: 1202
   skip: True  # [not osx]
 
 requirements:


### PR DESCRIPTION
Bump build number to ensure Python versions in `python.app` and `python` are the exact same. This is a temporary fix for #8.

cc @cbrnr